### PR TITLE
Improve Windows test reliability

### DIFF
--- a/cli/azd/AGENTS.md
+++ b/cli/azd/AGENTS.md
@@ -359,7 +359,10 @@ This project uses Go 1.26. Use modern standard library features:
 ### Testing Best Practices
 
 - **Test the actual rules, not just the framework**: When adding YAML-based error suggestion rules, write tests that exercise the rules end-to-end through the pipeline, not just tests that validate the framework's generic matching behavior
-- **Extract shared test helpers**: Don't duplicate test utilities across files. Extract common helpers (e.g., shell wrappers, auth token fetchers, CLI runners) into shared `test_utils` packages. Duplication across 3+ files should always be refactored
+- **Search for prior art before adding helpers**: Search `test/`, `pkg/osutil`, and the package under test before adding cleanup, retry, process, or platform-specific helpers. Reuse or promote existing behavior and extract shared test utilities instead of creating parallel implementations
+- **Isolate persistent user state**: Functional tests that install extensions or mutate config, auth, cache, or other user-level state must set `AZD_CONFIG_DIR` to a dedicated `tempDirWithDiagnostics(t)` directory. Never let parallel tests read or modify the developer/agent's default `~/.azd` state
+- **Make cleanup process-safe**: Wait for spawned commands to finish, register cleanup when state is created, and report failures. Use `osutil.RemoveAll` for directories containing executed binaries because Windows may retain transient locks; keep retries at the filesystem boundary instead of adding test sleeps. Since `t.Context()` is canceled before cleanup runs, use a separate bounded context when cleanup needs one
+- **Guard fixture type assertions**: Check presence and type with `require` before casting values loaded from maps, JSON, environment files, or recordings. A raw type assertion panic can abort the package and hide the initiating failure
 - **Use correct env vars for testing**:
   - Non-interactive mode: `AZD_FORCE_TTY=false` (not `AZD_DEBUG_FORCE_NO_TTY`, which doesn't exist)
   - No-prompt mode: use the `--no-prompt` flag for core azd commands; `AZD_NO_PROMPT=true` is only used for propagating no-prompt into extension subprocesses
@@ -370,7 +373,7 @@ This project uses Go 1.26. Use modern standard library features:
 - **Cross-platform paths**: When resolving binary paths in tests, handle `.exe` suffix on Windows (e.g., `azd` vs `azd.exe` via `process.platform === "win32"`)
 - **Test new JSON fields**: When adding fields to JSON command output (e.g., `expiresOn` in `azd auth status --output json`), add a test asserting the field's presence and format
 - **No unused dependencies**: Don't add npm/pip packages that aren't imported anywhere. Remove dead `devDependencies` before submitting
-- **Never write to `os.Stdout` in tests**: Tests that write directly to `os.Stdout` (via `fmt.Print*`, `os.Stdout`, or UX components like `ux.NewSpinner` without a `Writer` option) corrupt the `go test -json` event stream under parallel execution, causing phantom test failures in CI. Use `t.Log`/`t.Logf` for diagnostic output, `io.Discard` or `&bytes.Buffer{}` for UX component writers, and `SkipLoadingSpinner: true` for prompt tests that don't need spinner behavior. Enforced by the `forbidigo` linter in `.golangci.yaml`. See [#8385](https://github.com/Azure/azure-dev/issues/8385) for details.
+- **Keep terminal output on the injected writer**: Commands and UX components must pass the caller's `io.Writer` to every nested spinner, prompt, cursor, and formatter. In tests, use `t.Log`/`t.Logf` for diagnostics and `io.Discard` or `&bytes.Buffer{}` for UX writers. Raw stdout corrupts `go test -json` and creates phantom CI failures. `forbidigo` blocks direct writes in tests, but production writer propagation still needs buffer-based coverage. See [#8385](https://github.com/Azure/azure-dev/issues/8385)
 
 ## MCP Tools
 

--- a/cli/azd/cmd/tool.go
+++ b/cli/azd/cmd/tool.go
@@ -897,6 +897,7 @@ func detectAllTools(
 	ctx context.Context,
 	manager *tool.Manager,
 	formatter output.Formatter,
+	writer io.Writer,
 	spinnerText string,
 ) ([]*tool.ToolStatus, error) {
 	if formatter != nil && formatter.Kind() == output.JsonFormat {
@@ -907,6 +908,7 @@ func detectAllTools(
 	spinner := uxlib.NewSpinner(&uxlib.SpinnerOptions{
 		Text:        spinnerText,
 		ClearOnStop: true,
+		Writer:      writer,
 	})
 	if err := spinner.Run(ctx, func(ctx context.Context) error {
 		var detectErr error
@@ -1080,7 +1082,7 @@ func (a *toolInstallAction) resolveToolIds(ctx context.Context) ([]string, error
 
 	// --all: install all recommended tools that are not already installed.
 	if a.flags.all {
-		statuses, err := detectAllTools(ctx, a.manager, a.formatter, "Detecting tool status...")
+		statuses, err := detectAllTools(ctx, a.manager, a.formatter, a.writer, "Detecting tool status...")
 		if err != nil {
 			return nil, fmt.Errorf("detecting tools: %w", err)
 		}
@@ -1100,7 +1102,7 @@ func (a *toolInstallAction) resolveToolIds(ctx context.Context) ([]string, error
 	}
 
 	// Interactive: let the user pick from uninstalled tools.
-	statuses, err := detectAllTools(ctx, a.manager, a.formatter, "Detecting tool status...")
+	statuses, err := detectAllTools(ctx, a.manager, a.formatter, a.writer, "Detecting tool status...")
 	if err != nil {
 		return nil, fmt.Errorf("detecting tools: %w", err)
 	}
@@ -1439,7 +1441,7 @@ func (a *toolUpgradeAction) Run(ctx context.Context) (*actions.ActionResult, err
 // detectInstalledTools runs DetectAll behind a spinner and returns the full
 // set of tool statuses. Used by the --all and interactive upgrade paths.
 func (a *toolUpgradeAction) detectInstalledTools(ctx context.Context) ([]*tool.ToolStatus, error) {
-	statuses, err := detectAllTools(ctx, a.manager, a.formatter, "Detecting installed tools...")
+	statuses, err := detectAllTools(ctx, a.manager, a.formatter, a.writer, "Detecting installed tools...")
 	if err != nil {
 		return nil, fmt.Errorf("detecting installed tools: %w", err)
 	}
@@ -1757,7 +1759,7 @@ func (a *toolUninstallAction) resolveToolIds(ctx context.Context) ([]string, err
 
 	// --all, --dry-run, and the interactive picker all need the current
 	// installed set.
-	statuses, err := detectAllTools(ctx, a.manager, a.formatter, "Detecting installed tools...")
+	statuses, err := detectAllTools(ctx, a.manager, a.formatter, a.writer, "Detecting installed tools...")
 	if err != nil {
 		return nil, fmt.Errorf("detecting installed tools: %w", err)
 	}

--- a/cli/azd/docs/recording-functional-tests-guide.md
+++ b/cli/azd/docs/recording-functional-tests-guide.md
@@ -156,6 +156,7 @@ func Test_CLI_MyNewFeature(t *testing.T) {
 
     // Create a temporary directory for test files
     dir := tempDirWithDiagnostics(t)
+    configDir := tempDirWithDiagnostics(t)
     t.Logf("DIR: %s", dir)
 
     // Start the recording session
@@ -170,6 +171,8 @@ func Test_CLI_MyNewFeature(t *testing.T) {
     cli.WorkingDirectory = dir
     cli.Env = append(cli.Env, os.Environ()...)
     cli.Env = append(cli.Env, "AZURE_LOCATION=eastus2")
+    // Required when the test installs extensions or changes user-level azd state.
+    cli.Env = append(cli.Env, "AZD_CONFIG_DIR="+configDir)
 
     // Setup cleanup (only runs in live mode, not playback)
     defer cleanupDeployments(ctx, t, cli, session, envName)
@@ -718,7 +721,17 @@ if session == nil {
 }
 ```
 
-### 7. Add Debug Logging
+### 7. Isolate State and Use Shared Cleanup
+
+Tests that install extensions or modify azd configuration, authentication, caches, or other user-level state must use
+a private `AZD_CONFIG_DIR`, as shown in the example above. Functional tests run in parallel; using the default
+`~/.azd` directory can contaminate unrelated tests or modify a developer's installation.
+
+Use `tempDirWithDiagnostics(t)` for generated or executed files. It retries transient Windows file locks and reports
+lock diagnostics if cleanup fails. Register other cleanup when state is created; don't duplicate retry loops or add
+fixed sleeps. Since `t.Context()` is canceled before cleanup runs, use a separate bounded context when needed.
+
+### 8. Add Debug Logging
 
 ```go
 t.Logf("Recording mode: playback=%v", session != nil && session.Playback)
@@ -726,7 +739,7 @@ t.Logf("Environment name: %s", envName)
 t.Logf("Subscription ID: %s", subscriptionId)
 ```
 
-### 8. Handle Skipped Tests Gracefully
+### 9. Handle Skipped Tests Gracefully
 
 **DO**:
 ```go
@@ -1022,10 +1035,12 @@ os.Setenv("AZD_TEST_FIXED_CLOCK_UNIX_TIME", "1744738873")
 - [ ] Start with `recording.Start(t)`
 - [ ] Use `randomOrStoredEnvName(session)`
 - [ ] Create CLI with `azdcli.WithSession(session)`
+- [ ] Set a private `AZD_CONFIG_DIR` when the test changes user-level state
 - [ ] Use `session.ProxyClient` for HTTP operations
 - [ ] Store dynamic values in `session.Variables`
-- [ ] Add cleanup with session checks
+- [ ] Use `tempDirWithDiagnostics(t)` and register other cleanup immediately
 - [ ] Use appropriate timeouts for recording/playback
+- [ ] Guard fixture type assertions so malformed data fails the test without panicking
 
 ### Recording a Test ✓
 - [ ] Set `AZURE_RECORD_MODE=record`
@@ -1056,8 +1071,3 @@ os.Setenv("AZD_TEST_FIXED_CLOCK_UNIX_TIME", "1744738873")
 - **Test Helpers**: `cli/azd/test/azdcli/`
 - **Example Tests**: `cli/azd/test/functional/up_test.go`
 - **go-vcr Documentation**: https://github.com/dnaeon/go-vcr
-
----
-
-**Last Updated**: December 2025  
-**Maintainers**: Azure Developer CLI Team

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -795,16 +795,8 @@ func (m *Manager) Uninstall(id string) error {
 	}
 
 	extensionDir := filepath.Join(userConfigDir, "extensions", extension.Id)
-	if err := os.MkdirAll(extensionDir, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create target directory: %w", err)
-	}
-
-	// Remove the extension artifacts when it exists
-	_, err = os.Stat(extensionDir)
-	if err == nil {
-		if err := os.RemoveAll(extensionDir); err != nil {
-			return fmt.Errorf("failed to remove extension: %w", err)
-		}
+	if err := osutil.RemoveAll(context.Background(), extensionDir); err != nil {
+		return fmt.Errorf("failed to remove extension: %w", err)
 	}
 
 	// Update the user config

--- a/cli/azd/pkg/osutil/rename_unix.go
+++ b/cli/azd/pkg/osutil/rename_unix.go
@@ -14,3 +14,8 @@ import (
 func Rename(ctx context.Context, old, new string) error {
 	return os.Rename(old, new)
 }
+
+// RemoveAll removes path and any children it contains.
+func RemoveAll(_ context.Context, path string) error {
+	return os.RemoveAll(path)
+}

--- a/cli/azd/pkg/osutil/rename_windows.go
+++ b/cli/azd/pkg/osutil/rename_windows.go
@@ -8,6 +8,7 @@ package osutil
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -20,15 +21,24 @@ import (
 // Rename fails due to what may be transient file system errors. This can help work around issues where the file may
 // temporary be opened by a virus scanner or some other process which prevents us from renaming the file.
 func Rename(ctx context.Context, old, new string) error {
-	return retry.Do(ctx, retry.WithMaxRetries(10, retry.NewConstant(1*time.Second)), func(ctx context.Context) error {
-		err := os.Rename(old, new)
-		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
-			// If some other process has a open handle to the source file, Rename can fail with ERROR_SHARING_VIOLATION.
-			log.Printf("rename of %s to %s failed due to ERROR_SHARING_VIOLATION, allowing retry", old, new)
-			return retry.RetryableError(err)
-		} else if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
-			// If the target file has already exists and is in use, Rename can fail with ERROR_ACCESS_DENIED.
-			log.Printf("rename of %s to %s failed due to ERROR_ACCESS_DENIED, allowing retry", old, new)
+	return retryFileSystemOperation(ctx, fmt.Sprintf("rename of %s to %s", old, new), func() error {
+		return os.Rename(old, new)
+	})
+}
+
+// RemoveAll removes path and any children it contains, retrying transient Windows file locks.
+func RemoveAll(ctx context.Context, path string) error {
+	return retryFileSystemOperation(ctx, fmt.Sprintf("remove of %s", path), func() error {
+		return os.RemoveAll(path)
+	})
+}
+
+func retryFileSystemOperation(ctx context.Context, description string, operation func() error) error {
+	return retry.Do(ctx, retry.WithMaxRetries(10, retry.NewConstant(time.Second)), func(context.Context) error {
+		err := operation()
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+			errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			log.Printf("%s failed due to a transient file lock, allowing retry", description)
 			return retry.RetryableError(err)
 		}
 		return err

--- a/cli/azd/pkg/osutil/rename_windows_test.go
+++ b/cli/azd/pkg/osutil/rename_windows_test.go
@@ -61,3 +61,17 @@ func TestRename(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestRemoveAll_FileInUse(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.Create(filepath.Join(dir, "locked"))
+	assert.NoError(t, err)
+
+	go func() {
+		time.Sleep(time.Second)
+		_ = file.Close()
+	}()
+
+	assert.NoError(t, RemoveAll(t.Context(), dir))
+	assert.NoDirExists(t, dir)
+}

--- a/cli/azd/pkg/ux/confirm.go
+++ b/cli/azd/pkg/ux/confirm.go
@@ -94,7 +94,7 @@ func NewConfirm(options *ConfirmOptions) *Confirm {
 	}
 
 	return &Confirm{
-		input:        internal.NewInput(),
+		input:        internal.NewInput(mergedOptions.Writer),
 		options:      &mergedOptions,
 		displayValue: displayValue,
 		value:        mergedOptions.DefaultValue,

--- a/cli/azd/pkg/ux/multi_select.go
+++ b/cli/azd/pkg/ux/multi_select.go
@@ -119,7 +119,7 @@ func NewMultiSelect(options *MultiSelectOptions) *MultiSelect {
 	}
 
 	return &MultiSelect{
-		input:           internal.NewInput(),
+		input:           internal.NewInput(mergedOptions.Writer),
 		cursor:          internal.NewCursor(mergedOptions.Writer),
 		options:         &mergedOptions,
 		filteredChoices: selectOptions,

--- a/cli/azd/pkg/ux/prompt.go
+++ b/cli/azd/pkg/ux/prompt.go
@@ -106,7 +106,7 @@ func NewPrompt(options *PromptOptions) *Prompt {
 	}
 
 	return &Prompt{
-		input:   internal.NewInput(),
+		input:   internal.NewInput(mergedOptions.Writer),
 		options: &mergedOptions,
 		value:   mergedOptions.DefaultValue,
 	}

--- a/cli/azd/pkg/ux/select.go
+++ b/cli/azd/pkg/ux/select.go
@@ -112,7 +112,7 @@ func NewSelect(options *SelectOptions) *Select {
 	}
 
 	return &Select{
-		input:           internal.NewInput(),
+		input:           internal.NewInput(mergedOptions.Writer),
 		cursor:          internal.NewCursor(mergedOptions.Writer),
 		options:         &mergedOptions,
 		filteredChoices: selectOptions,

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -23,7 +23,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -44,7 +43,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/recording"
 	"github.com/benbjohnson/clock"
 	"github.com/joho/godotenv"
-	"github.com/sethvargo/go-retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
@@ -1018,7 +1016,7 @@ func tempDirWithDiagnostics(t *testing.T) string {
 	if runtime.GOOS == "windows" {
 		// Enable our additional custom remove logic for Windows where we see locked files.
 		t.Cleanup(func() {
-			err := removeAllWithDiagnostics(t, temp)
+			err := osutil.RemoveAll(context.Background(), temp)
 			if err != nil {
 				logHandles(t, temp)
 				t.Fatalf("TempDirWithDiagnostics: %s", err)
@@ -1059,29 +1057,6 @@ func logHandles(t *testing.T, path string) {
 	span.SetAttributes(attribute.String("handle.stdout", rr.Stdout))
 	span.SetAttributes(attribute.String("ci.build.number", os.Getenv("BUILD_BUILDNUMBER")))
 	span.End()
-}
-
-func removeAllWithDiagnostics(t *testing.T, path string) error {
-	retryCount := 0
-	loggedOnce := false
-	return retry.Do(context.Background(), retry.WithMaxRetries(10, retry.NewConstant(1*time.Second)),
-		func(_ context.Context) error {
-			removeErr := os.RemoveAll(path)
-			if removeErr == nil {
-				return nil
-			}
-			t.Logf("failed to clean up %s with error: %v", path, removeErr)
-
-			if retryCount >= 2 && !loggedOnce {
-				// Only log once after 2 seconds - logHandles is pretty expensive and slow
-				logHandles(t, path)
-				loggedOnce = true
-			}
-
-			retryCount++
-			return retry.RetryableError(removeErr)
-		},
-	)
 }
 
 // Assert that all supported types from the infrastructure provider is marshalled and stored correctly in the environment.

--- a/cli/azd/test/functional/extension_test.go
+++ b/cli/azd/test/functional/extension_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
 	"github.com/azure/azure-dev/cli/azd/test/recording"
 	"github.com/stretchr/testify/require"
@@ -27,8 +28,12 @@ func Test_CLI_Extension_ForceInstall(t *testing.T) {
 	ctx, cancel := newTestContext(t)
 	defer cancel()
 
+	configDir := tempDirWithDiagnostics(t)
 	cli := azdcli.NewCLI(t)
-	cli.Env = append(cli.Env, os.Environ()...)
+	cli.Env = append(os.Environ(),
+		"AZD_CONFIG_DIR="+configDir,
+		"AZURE_DEV_COLLECT_TELEMETRY=no",
+	)
 
 	// Setup: Add local extension source
 	sourcePath := azdcli.GetSourcePath()
@@ -40,9 +45,13 @@ func Test_CLI_Extension_ForceInstall(t *testing.T) {
 	// Cleanup function to ensure extension is uninstalled and source removed
 	defer func() {
 		t.Log("Cleaning up: uninstalling microsoft.azd.demo extension")
-		_, _ = cli.RunCommand(ctx, "ext", "uninstall", "microsoft.azd.demo")
+		if _, err := cli.RunCommand(ctx, "ext", "uninstall", "microsoft.azd.demo"); err != nil {
+			t.Logf("warning: failed to uninstall microsoft.azd.demo: %v", err)
+		}
 		t.Log("Cleaning up: removing test-local source")
-		_, _ = cli.RunCommand(ctx, "ext", "source", "remove", "test-local")
+		if _, err := cli.RunCommand(ctx, "ext", "source", "remove", "test-local"); err != nil {
+			t.Logf("warning: failed to remove test-local source: %v", err)
+		}
 	}()
 
 	// Step 1: Install the latest version of microsoft.azd.demo extension
@@ -104,13 +113,11 @@ func Test_CLI_Extension_ForceInstall(t *testing.T) {
 	t.Logf("Testing reinstall of same version (%s) with --force", targetVersion)
 
 	// Get the extension binary path before deletion
-	homeDir, err := os.UserHomeDir()
-	require.NoError(t, err)
-	extPath := filepath.Join(homeDir, ".azd", "extensions", "microsoft.azd.demo")
+	extPath := filepath.Join(configDir, "extensions", "microsoft.azd.demo")
 
 	// Delete the extension files but keep the metadata
 	t.Log("Deleting extension files to simulate corruption")
-	err = os.RemoveAll(extPath)
+	err = osutil.RemoveAll(t.Context(), extPath)
 	require.NoError(t, err)
 
 	// Try to install without --force (should skip)

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -191,10 +191,14 @@ func Test_CLI_Up_Down_FuncApp(t *testing.T) {
 	require.NoError(t, err)
 
 	if session != nil {
-		session.Variables[recording.SubscriptionIdKey] = envValues[environment.SubscriptionIdEnvVarName].(string)
+		subID, ok := envValues[environment.SubscriptionIdEnvVarName].(string)
+		require.True(t, ok, "AZURE_SUBSCRIPTION_ID should be a string in env values")
+		session.Variables[recording.SubscriptionIdKey] = subID
 	}
 
-	url := fmt.Sprintf("%s/api/httptrigger", envValues["AZURE_FUNCTION_URI"])
+	funcURI, ok := envValues["AZURE_FUNCTION_URI"].(string)
+	require.True(t, ok, "AZURE_FUNCTION_URI should be a string in env values")
+	url := fmt.Sprintf("%s/api/httptrigger", funcURI)
 	t.Logf("Issuing GET request to function\n")
 
 	// We've seen some cases in CI where issuing a get right after a deploy ends up with us getting a 404, so retry the

--- a/docs/guides/adding-a-new-command.md
+++ b/docs/guides/adding-a-new-command.md
@@ -88,6 +88,13 @@ After adding the command, regenerate CLI snapshots:
 UPDATE_SNAPSHOTS=true go test ./cmd -run 'TestFigSpec|TestUsage'
 ```
 
+### 5. Check reliability boundaries
+
+- Pass the injected `io.Writer` to nested formatters, spinners, and prompts. For terminal UX changes, verify
+  `go test -json` contains only JSON events.
+- Functional tests that modify user-level state must use an isolated `AZD_CONFIG_DIR`. See
+  [Recording functional tests](../../cli/azd/docs/recording-functional-tests-guide.md).
+
 ## Design Principles
 
 - **Verb-first structure:** Use simple verbs (`up`, `add`, `deploy`) with minimal nesting


### PR DESCRIPTION
## Summary
- Retry transient Windows file locks during extension cleanup and isolate extension functional-test state.
- Keep prompt and spinner output on injected writers so `go test -json` remains valid.
- Prevent fixture panics and document the reliability patterns.

## Tests
- Targeted command, UX, extension, OS utility, and force-install functional tests.