### PR TITLE
Temporary ext registry check E2E canary

### DIFF
--- a/cli/azd/extensions/registry.dev.json
+++ b/cli/azd/extensions/registry.dev.json
@@ -4,7 +4,7 @@
     {
       "id": "azure.ai.training",
       "namespace": "ai.training",
-      "displayName": "Microsoft Foundry Training (Preview)",
+      "displayName": "Microsoft Foundry Training (Preview) E2E",
       "description": "Extension for Microsoft Foundry training jobs. (Preview)",
       "versions": [
         {

--- a/cli/azd/extensions/registry.dev.json
+++ b/cli/azd/extensions/registry.dev.json
@@ -3,7 +3,7 @@
   "extensions": [
     {
       "id": "azure.ai.training",
-      "namespace": "ai.training",
+      "namespace": "ai.training.e2e",
       "displayName": "Microsoft Foundry Training (Preview) E2E",
       "description": "Extension for Microsoft Foundry training jobs. (Preview)",
       "versions": [


### PR DESCRIPTION
Temporary canary PR to validate registry.dev.json policy end-to-end. This PR will be closed and its branches deleted after testing.